### PR TITLE
Add additional Camera controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@
 
 ## Camera Controls
 - Forwards/Backwards: `W`/`S`
-- Pitch/Yaw: Arrow Keys
+- Strafe Left/Right: `A`/`D`
+- Pitch/Yaw: Arrow Keys or Mouse

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -8,7 +8,7 @@ pub struct Camera {
     up: cgmath::Vector3<f32>,
 
     // control
-    view_move: (bool, bool),
+    view_move: (bool, bool, bool, bool),
     view_rotate: (bool, bool, bool, bool),
 }
 
@@ -23,14 +23,14 @@ impl Camera {
             rotation: rotation,
             up: up,
 
-            // forward/backward movement
-            view_move: (false, false),
+            // forward/left/backward/right (WASD) movement
+            view_move: (false, false, false, false),
             // left/up/right/down rotation,
             view_rotate: (false, false, false, false),
         }
     }
 
-    pub fn on_event(&mut self, input: winit::KeyboardInput) {
+    pub fn on_keyboard(&mut self, input: winit::KeyboardInput) {
         let winit::KeyboardInput {
             virtual_keycode,
             state,
@@ -38,10 +38,14 @@ impl Camera {
         } = input;
         match (state, virtual_keycode) {
             (ElementState::Pressed, Some(VirtualKeyCode::W)) => self.view_move.0 = true,
-            (ElementState::Pressed, Some(VirtualKeyCode::S)) => self.view_move.1 = true,
+            (ElementState::Pressed, Some(VirtualKeyCode::A)) => self.view_move.1 = true,
+            (ElementState::Pressed, Some(VirtualKeyCode::S)) => self.view_move.2 = true,
+            (ElementState::Pressed, Some(VirtualKeyCode::D)) => self.view_move.3 = true,
 
             (ElementState::Released, Some(VirtualKeyCode::W)) => self.view_move.0 = false,
-            (ElementState::Released, Some(VirtualKeyCode::S)) => self.view_move.1 = false,
+            (ElementState::Released, Some(VirtualKeyCode::A)) => self.view_move.1 = false,
+            (ElementState::Released, Some(VirtualKeyCode::S)) => self.view_move.2 = false,
+            (ElementState::Released, Some(VirtualKeyCode::D)) => self.view_move.3 = false,
 
             (ElementState::Pressed, Some(VirtualKeyCode::Left)) => self.view_rotate.0 = true,
             (ElementState::Pressed, Some(VirtualKeyCode::Up)) => self.view_rotate.1 = true,
@@ -56,17 +60,42 @@ impl Camera {
         }
     }
 
+    pub fn on_mouse(&mut self, delta: (f64, f64)){
+        let view_rot_speed = cgmath::Rad(0.01f32);
+        let dx = delta.0 as f32;
+        let dy = delta.1 as f32;
+        self.rotation.0 = self.rotation.0 - view_rot_speed * dx;
+        self.rotation.1 = self.rotation.1 - view_rot_speed * dy;
+
+        // clamping
+        let min_y_rotation = cgmath::Rad(-1.0f32);
+        let max_y_rotation = cgmath::Rad(1.0f32);
+        if self.rotation.1 < min_y_rotation {
+            self.rotation.1 = min_y_rotation;
+        }
+        if self.rotation.1 > max_y_rotation {
+            self.rotation.1 = max_y_rotation;
+        }
+    }
+
     pub fn update(&mut self, dt: f32) {
         let view_move_speed = 100.0f32;
         let view_rot_speed = cgmath::Rad(1.0f32);
         let view_dir = self.get_view_dir();
+        let tangent_dir = self.up.cross(view_dir);
 
         // move forward/backward
         if self.view_move.0 {
             self.pos = self.pos + view_dir * (view_move_speed * dt);
         }
         if self.view_move.1 {
+            self.pos = self.pos + tangent_dir * (view_move_speed * dt);
+        }
+        if self.view_move.2 {
             self.pos = self.pos + view_dir * (-view_move_speed * dt);
+        }
+        if self.view_move.3 {
+            self.pos = self.pos + tangent_dir * (-view_move_speed * dt);
         }
 
         // rotate camera
@@ -78,10 +107,20 @@ impl Camera {
         }
         if self.view_rotate.1 {
             self.rotation.1 = self.rotation.1 + view_rot_speed * dt;
-        } // todo: clamp
+        }
         if self.view_rotate.3 {
             self.rotation.1 = self.rotation.1 - view_rot_speed * dt;
-        } // todo: clamp
+        }
+
+        // clamping
+        let min_y_rotation = cgmath::Rad(-1.0f32);
+        let max_y_rotation = cgmath::Rad(1.0f32);
+        if self.rotation.1 < min_y_rotation {
+            self.rotation.1 = min_y_rotation;
+        }
+        if self.rotation.1 > max_y_rotation {
+            self.rotation.1 = max_y_rotation;
+        }
     }
 
     fn get_view_dir(&self) -> cgmath::Vector3<f32> {

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -67,15 +67,7 @@ impl Camera {
         self.rotation.0 = self.rotation.0 - view_rot_speed * dx;
         self.rotation.1 = self.rotation.1 - view_rot_speed * dy;
 
-        // clamping
-        let min_y_rotation = cgmath::Rad(-1.0f32);
-        let max_y_rotation = cgmath::Rad(1.0f32);
-        if self.rotation.1 < min_y_rotation {
-            self.rotation.1 = min_y_rotation;
-        }
-        if self.rotation.1 > max_y_rotation {
-            self.rotation.1 = max_y_rotation;
-        }
+        self.clamp_pitch();
     }
 
     pub fn update(&mut self, dt: f32) {
@@ -112,15 +104,7 @@ impl Camera {
             self.rotation.1 = self.rotation.1 - view_rot_speed * dt;
         }
 
-        // clamping
-        let min_y_rotation = cgmath::Rad(-1.0f32);
-        let max_y_rotation = cgmath::Rad(1.0f32);
-        if self.rotation.1 < min_y_rotation {
-            self.rotation.1 = min_y_rotation;
-        }
-        if self.rotation.1 > max_y_rotation {
-            self.rotation.1 = max_y_rotation;
-        }
+        self.clamp_pitch();
     }
 
     fn get_view_dir(&self) -> cgmath::Vector3<f32> {
@@ -145,5 +129,18 @@ impl Camera {
 
     pub fn position(&self) -> [f32; 3] {
         self.pos.into()
+    }
+
+    fn clamp_pitch(&mut self) {
+        // clamp to a little less than [-pi/2, pi/2]
+        let min_y_rotation = cgmath::Rad(-1.5f32);
+        let max_y_rotation = cgmath::Rad(1.5f32);
+
+        if self.rotation.1 < min_y_rotation {
+            self.rotation.1 = min_y_rotation;
+        }
+        if self.rotation.1 > max_y_rotation {
+            self.rotation.1 = max_y_rotation;
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1044,22 +1044,29 @@ fn main() {
     let mut running = true;
     while running {
         events_loop.poll_events(|event| {
-            if let winit::Event::WindowEvent { event, .. } = event {
-                match event {
-                    winit::WindowEvent::KeyboardInput {
-                        input:
-                            winit::KeyboardInput {
-                                virtual_keycode: Some(winit::VirtualKeyCode::Escape),
-                                ..
-                            },
-                        ..
+            match event {
+                winit::Event::WindowEvent { event, .. } => {
+                    match event {
+                        winit::WindowEvent::KeyboardInput {
+                            input:
+                                winit::KeyboardInput {
+                                    virtual_keycode: Some(winit::VirtualKeyCode::Escape),
+                                    ..
+                                },
+                            ..
+                        }
+                        | winit::WindowEvent::Closed => running = false,
+                        winit::WindowEvent::KeyboardInput { input, .. } => {
+                            camera.on_keyboard(input);
+                        }
+                        _ => (),
                     }
-                    | winit::WindowEvent::Closed => running = false,
-                    winit::WindowEvent::KeyboardInput { input, .. } => {
-                        camera.on_event(input);
-                    }
-                    _ => (),
                 }
+                winit::Event::DeviceEvent {
+                    event: winit::DeviceEvent::MouseMotion { delta }, .. } => {
+                        camera.on_mouse(delta);
+                }
+                _ => (),
             }
         });
 


### PR DESCRIPTION
Hi!

Awesome project!

I am taking a Graphics class this semester that has gotten me really interested in the field. So far in our class, we have implemented a ray tracer and made a project using OpenGL (we actually had to make an ocean for part of it but it was much [more simple](http://daviskr.com/RandomProjects/PocketOcean/) than this one haha).

Anyways, I have always been interested in Rust but have never actually worked on any projects using it. I found this project via the [gfx-rs website](http://gfx-rs.github.io/2017/12/30/this-year.html) and was very impressed. When I ran the program (took a while to start on my MacBook Air), I noticed that there was no mouse or strafing control. This was great because it was something I knew the basic idea of how to implement!

Changes made:
 - [Bind the mouse](https://docs.rs/winit/0.11.1/winit/enum.DeviceEvent.html#variant.MouseMotion) to control pitch and yaw along with the arrow keys
 - Make `A` and `D` strafe left and right, respectively
 - Clamp up and down rotation to avoid getting the camera inverted

I would really appreciate any feedback! This is my first time pushing Rust code, so I am super eager to learn how to improve!

Thanks!